### PR TITLE
Add backend setup instructions for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ This guide expects that you have [Python](https://www.python.org/downloads/) (At
 
 3. **Install PostgreSQL (version 17)** ***(THIS WILL TAKE A LONG TIME)***
 	- Windows: https://www.postgresql.org/download/windows/
-	- Mac: https://www.postgresql.org/download/macosx/
 	- Linux: https://www.postgresql.org/download/linux/
 
 4. **Activate the venv (if it's not already active) using the corresponding command and install psycopg2**
@@ -198,11 +197,11 @@ If Python was installed via either Homebrew or the official Python installer, yo
     psql
     ```
 
-    6a. If psql is not found, try this solution
-		```sh
-        brew install pgcli
-		brew link --force libpq
-        ```
+    6a. *If psql is not found, try this solution*
+	```sh
+    brew install pgcli
+	brew link --force libpq
+    ```
 
 7. **Run the following SQL commands:**
 	

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ If Python was installed via either Homebrew or the official Python installer, yo
     psql
     ```
 
+    6a. If psql is not found, try this solution
+		```sh
+        brew install pgcli
+		brew link --force libpq
+        ```
+
 7. **Run the following SQL commands:**
 	
     ```sql

--- a/README.md
+++ b/README.md
@@ -157,19 +157,19 @@ If Python was installed via either Homebrew or the official Python installer, yo
 ### Setup
 1. **Create the venv**
 
-    ```sh
+    ```zsh
     cd Studygatchi
 	python3 -m venv env
     ```
     To activate the venv:
 
-    ```sh
+    ```zsh
     source /env/bin/activate
     ```
 
 2. **Run the following commands to install Django and the Django Rest Framework:**
     
-    ```sh
+    ```zsh
     pip3 install django
     pip3 install djangorestframework
     ```
@@ -179,26 +179,26 @@ If Python was installed via either Homebrew or the official Python installer, yo
 
 4. **Activate the venv (if it's not already active) using the corresponding command and install psycopg2**
 	
-    ```sh
+    ```zsh
     pip3 install psycopg2-binary
     ```
     We will use this to be able to connect Django with Postgres!
 
 5. **Create a database for Studygatchi**
 
-    ```sh
+    ```zsh
     createdb studygatchi_db
     ```
 
 6. **Access the PostgreSQL shell, logged in as the superuser:**
     
-    ```sh
+    ```zsh
     cd <directory you installed it to>/env/bin
     psql
     ```
 
-    6a. *If psql is not found, try this solution*
-	```sh
+    6a. ***If psql is not found, try this solution***
+	```zsh
     brew install pgcli
 	brew link --force libpq
     ```
@@ -212,6 +212,7 @@ If Python was installed via either Homebrew or the official Python installer, yo
 	\q
     ```
 	Replace `<myprojectuser>` with whatever username you want, same for the password;
+    
     Use `quit` to exit the PostgreSQL shell;
 
 8. **Create a file called `settings.py` in the backend directory and copy and paste the contents of `settings_template.txt` into `settings.py`.**
@@ -220,14 +221,14 @@ If Python was installed via either Homebrew or the official Python installer, yo
 
 10. **Run the following commands** ***with the venv active*** **to apply migrations:**
     
-    ```sh
+    ```zsh
 	python3 manage.py makemigrations
 	python3 manage.py migrate
     ```
 
 11. **Test the connection by running this command:**
 	
-    ```sh
+    ```zsh
     python3 manage.py runserver
     ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This will generate the build files in the `build` directory.
 - `tsconfig.json`: TypeScript configuration file.
 - `package.json`: Contains the project dependencies and scripts.
 
-## Backend
+## Backend (Windows/Linux)
 
 ### Prerequisites
 This guide expects that you have [Python](https://www.python.org/downloads/) (At least 3.12.0) installed.
@@ -147,4 +147,83 @@ This guide expects that you have [Python](https://www.python.org/downloads/) (At
     ```
 
 	If it all goes well, cool stuff, it's working!
+
+## Backend (Mac)
+
+### Prerequisites
+This guide expects that you have [Python](https://www.python.org/downloads/) (At least 3.12.0) installed. 
+
+If Python was installed via either Homebrew or the official Python installer, you may need to use ``python3`` and ``pip3`` instead for the terminal to work.
+
+### Setup
+1. **Create the venv**
+
+    ```sh
+    cd Studygatchi
+	python3 -m venv env
+    ```
+    To activate the venv:
+
+    ```sh
+    source /env/bin/activate
+    ```
+
+2. **Run the following commands to install Django and the Django Rest Framework:**
     
+    ```sh
+    pip3 install django
+    pip3 install djangorestframework
+    ```
+
+3. **Install PostgreSQL (version 17)** ***(THIS WILL TAKE A LONG TIME)***
+	- Mac: https://www.postgresql.org/download/macosx/
+
+4. **Activate the venv (if it's not already active) using the corresponding command and install psycopg2**
+	
+    ```sh
+    pip3 install psycopg2-binary
+    ```
+    We will use this to be able to connect Django with Postgres!
+
+5. **Create a database for Studygatchi**
+
+    ```sh
+    createdb studygatchi_db
+    ```
+
+6. **Access the PostgreSQL shell, logged in as the superuser:**
+    
+    ```sh
+    cd <directory you installed it to>/env/bin
+    psql
+    ```
+
+7. **Run the following SQL commands:**
+	
+    ```sql
+    CREATE USER <myprojectuser> WITH PASSWORD '<your_secure_password>';
+	CREATE DATABASE studygatchi_db OWNER <myprojectuser>;
+  	GRANT ALL PRIVILEGES ON DATABASE studygatchi_db TO <myprojectuser>;
+	\q
+    ```
+	Replace `<myprojectuser>` with whatever username you want, same for the password;
+    Use `quit` to exit the PostgreSQL shell;
+
+8. **Create a file called `settings.py` in the backend directory and copy and paste the contents of `settings_template.txt` into `settings.py`.**
+
+9. **In `settings.py`, go to where it says `DATABASES`, and insert your info from step 7 into the corresponding places.**
+
+10. **Run the following commands** ***with the venv active*** **to apply migrations:**
+    
+    ```sh
+	python3 manage.py makemigrations
+	python3 manage.py migrate
+    ```
+
+11. **Test the connection by running this command:**
+	
+    ```sh
+    python3 manage.py runserver
+    ```
+
+	If it all goes well, cool stuff, it's working!

--- a/backend/Backend Setup.txt
+++ b/backend/Backend Setup.txt
@@ -1,4 +1,4 @@
-Backend Setup:
+---------------- WINDOWS BACKEND SETUP ----------------
 
 1. Install Python & pip
 
@@ -39,5 +39,59 @@ Backend Setup:
 
 12. Test the connection by running this command
 	python manage.py runserver
+
+	If it all goes well cool stuff its working!
+
+---------------- MAC BACKEND SETUP ----------------
+
+1. Install Python & pip
+	You may need to use python3 & pip3 as your commands in the terminal
+
+2. Fork the repo
+
+3. Create and activate the venv
+	python3 -m venv env
+	source /bin/activate
+
+4. Install django framework via pip3
+	pip3 install djangorestframework
+
+5. Install PostgreSQL (THIS WILL TAKE A LONG TIME)
+	Mac: https://www.postgresql.org/download/macosx/
+
+6. Activate the venv and install psycopg2
+	pip3 install psycopg2-binary
+
+7. Access the PostgreSQL shell by cd into 'directory you installed it to'/bin
+	psql
+
+	7a. If psql is not found, try this solution
+		brew install pgcli
+		brew link --force libpq
+
+8. Create a local database
+	createdb "your-name"
+	replace "your-name" with anything else
+
+9. Type psql and run the following SQL commands
+	CREATE USER myprojectuser WITH PASSWORD 'your_secure_password';
+	CREATE DATABASE myprojectdb OWNER myprojectuser;
+  	GRANT ALL PRIVILEGES ON DATABASE myprojectdb TO myprojectuser;
+	\q
+
+	replace myprojectuser with whatever username you want, same for the password
+	replace myprojectdb with studygatchi_db
+
+10. Create a file called settings.py in the backend directory (in your Studygatchi folder) and 
+	copy and paste the contents of settings_template.txt into settings.py.
+
+11. On settings.py, go to where it says DATABASES, and insert your info from step 9 into the corresponding places.
+
+12. Run the following commands with the venv active to apply migrations:
+	python3 manage.py makemigrations
+	python3 manage.py migrate
+
+13. Test the connection by running this command
+	python3 manage.py runserver
 
 	If it all goes well cool stuff its working!


### PR DESCRIPTION
This request adds setup instructions for Mac users in ``README.md`` and ``Backend Setup.txt`` in the ``backend`` directory