### PR TITLE
Quick gitignore fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python environment
 env/
 __pycache__/
+backend/__pycache/*
 
 # personal settings
 backend/settings.py


### PR DESCRIPTION
Fixed the gitignore ignoring `__pycache__` directories (as it is supposed to) by adding a `backend/__pycache__/*` entry.