### PR TITLE
Removed build-addtl from running on PRs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -63,6 +63,7 @@ jobs:
 
   build-addtl:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
Removed the `build-addtl` tests from running on PRs.

Yes, this is a one-line PR but it's pretty important in my opinion.