### PR TITLE
fix: Do not run build-addtl on PRs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -80,6 +80,7 @@ jobs:
 
   build-addtl:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     services:
       postgres:
         image: postgres:16-alpine


### PR DESCRIPTION
Does the same thing as revision 2b33638, just with Docker.

Co-authored by: Andres D <84483578+fmcubium@users.noreply.github.com>