### PR TITLE
Add Task Endpoint

### DIFF
--- a/backend/quickstart/serializers.py
+++ b/backend/quickstart/serializers.py
@@ -49,4 +49,9 @@ class TaskSerializer(serializers.HyperlinkedModelSerializer):
     def validate_reward(self, value: int) -> int:
         if value < 0:
             raise serializers.ValidationError("Reward cannot be negative")
+
+        # Reward moderation will go here, for now we can have basic moderation and set a limit (like $100)
+        if value > 100:
+            raise serializers.ValidationError("Reward exceeds permitted amount")
+
         return value

--- a/backend/quickstart/tests.py
+++ b/backend/quickstart/tests.py
@@ -652,8 +652,12 @@ class TestTaskIsolation:
         self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
     ) -> None:
         """Task names aren't globally unique — two users can each have a task with the same name."""
-        Task.objects.create(name="Homework", reward=10, due_date="2029-12-31", user=test_user)
-        Task.objects.create(name="Homework", reward=20, due_date="2029-12-31", user=other_user)
+        Task.objects.create(
+            name="Homework", reward=10, due_date="2029-12-31T00:00:00Z", user=test_user
+        )
+        Task.objects.create(
+            name="Homework", reward=20, due_date="2029-12-31T00:00:00Z", user=other_user
+        )
 
         assert Task.objects.filter(name="Homework").count() == 2
         mine = Task.objects.get(name="Homework", user=test_user)
@@ -666,11 +670,11 @@ class TestTaskIsolation:
     ) -> None:
         """Sequential/guessable IDs shouldn't let one user fetch another's specific task."""
         task = Task.objects.create(
-            name="Secret Task", reward=10, due_date="2029-12-31", user=other_user
+            name="Secret Task", reward=10, due_date="2029-12-31T00:00:00Z", user=other_user
         )
 
         api_client.force_authenticate(user=test_user)
-        response = api_client.get(f"/api/get_task/", data={"id": task.id})
+        response = api_client.get("/api/get_task/", data={"id": task.id})
 
         assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
 
@@ -681,7 +685,7 @@ class TestTaskIsolation:
         api_client.force_authenticate(user=test_user)
         api_client.post(
             "/api/create_task/",
-            {"name": "First User Task", "reward": 5, "due_date": "2029-12-31"},
+            {"name": "First User Task", "reward": 5, "due_date": "2029-12-31T00:00:00Z"},
             format="json",
         )
 
@@ -695,12 +699,14 @@ class TestTaskIsolation:
         self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
     ) -> None:
         """Creating a task for one user shouldn't be influenced by or leak another user's existing tasks."""
-        Task.objects.create(name="Existing", reward=10, due_date="2029-12-31", user=other_user)
+        Task.objects.create(
+            name="Existing", reward=10, due_date="2029-12-31T00:00:00Z", user=other_user
+        )
 
         api_client.force_authenticate(user=test_user)
         response = api_client.post(
             "/api/create_task/",
-            {"name": "New Task", "reward": 5, "due_date": "2029-12-31"},
+            {"name": "New Task", "reward": 5, "due_date": "2029-12-31T00:00:00Z"},
             format="json",
         )
 
@@ -712,10 +718,18 @@ class TestTaskIsolation:
         self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
     ) -> None:
         """Total tasks in the DB across all users shouldn't affect what one user sees."""
-        Task.objects.create(name="Mine 1", reward=5, due_date="2029-12-31", user=test_user)
-        Task.objects.create(name="Theirs 1", reward=5, due_date="2029-12-31", user=other_user)
-        Task.objects.create(name="Theirs 2", reward=5, due_date="2029-12-31", user=other_user)
-        Task.objects.create(name="Theirs 3", reward=5, due_date="2029-12-31", user=other_user)
+        Task.objects.create(
+            name="Mine 1", reward=5, due_date="2029-12-31T00:00:00Z", user=test_user
+        )
+        Task.objects.create(
+            name="Theirs 1", reward=5, due_date="2029-12-31T00:00:00Z", user=other_user
+        )
+        Task.objects.create(
+            name="Theirs 2", reward=5, due_date="2029-12-31T00:00:00Z", user=other_user
+        )
+        Task.objects.create(
+            name="Theirs 3", reward=5, due_date="2029-12-31T00:00:00Z", user=other_user
+        )
 
         api_client.force_authenticate(user=test_user)
         response = api_client.get("/api/get_task/")
@@ -732,7 +746,7 @@ class TestTaskIsolation:
         for i in range(10):
             api_client.post(
                 "/api/create_task/",
-                {"name": f"Task {i}", "reward": 1, "due_date": "2029-12-31"},
+                {"name": f"Task {i}", "reward": 1, "due_date": "2029-12-31T00:00:00Z"},
                 format="json",
             )
 
@@ -746,8 +760,10 @@ class TestTaskIsolation:
         self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
     ) -> None:
         """Confirm reward/money fields on tasks aren't cross-contaminated between users' tasks."""
-        Task.objects.create(name="Cheap", reward=1, due_date="2029-12-31", user=test_user)
-        Task.objects.create(name="Expensive", reward=1000, due_date="2029-12-31", user=other_user)
+        Task.objects.create(name="Cheap", reward=1, due_date="2029-12-31T00:00:00Z", user=test_user)
+        Task.objects.create(
+            name="Expensive", reward=1000, due_date="2029-12-31T00:00:00Z", user=other_user
+        )
 
         api_client.force_authenticate(user=test_user)
         response = api_client.get("/api/get_task/")
@@ -762,12 +778,16 @@ class TestTaskIsolation:
         """Create tasks interleaved between two users, confirm isolation without relying on IDs."""
         api_client.force_authenticate(user=test_user)
         api_client.post(
-            "/api/create_task/", {"name": "A", "reward": 1, "due_date": "2029-12-31"}, format="json"
+            "/api/create_task/",
+            {"name": "A", "reward": 1, "due_date": "2029-12-31T00:00:00Z"},
+            format="json",
         )
 
         api_client.force_authenticate(user=other_user)
         api_client.post(
-            "/api/create_task/", {"name": "B", "reward": 1, "due_date": "2029-12-31"}, format="json"
+            "/api/create_task/",
+            {"name": "B", "reward": 1, "due_date": "2029-12-31T00:00:00Z"},
+            format="json",
         )
 
         api_client.force_authenticate(user=test_user)

--- a/backend/quickstart/tests.py
+++ b/backend/quickstart/tests.py
@@ -218,7 +218,9 @@ class TestTaskCreation:
 
         assert response.status_code == status.HTTP_201_CREATED
 
-    def test_create_task_excessive_reward(self, api_client: APIClient, test_user: StudyUser) -> None:
+    def test_create_task_excessive_reward(
+        self, api_client: APIClient, test_user: StudyUser
+    ) -> None:
         """A reward higher than the set limit should fail our current basic moderation"""
         # The value in this test is not 101 because this limit is subject to change
         api_client.force_authenticate(user=test_user)
@@ -421,9 +423,15 @@ class TestTaskRetrieval:
         """A user with several tasks should get all of them back."""
         api_client.force_authenticate(user=test_user)
 
-        Task.objects.create(name="Task A", reward=10, due_date="2029-12-31T00:00:00Z", user=test_user)
-        Task.objects.create(name="Task B", reward=20, due_date="2029-12-31T00:00:00Z", user=test_user)
-        Task.objects.create(name="Task C", reward=30, due_date="2029-12-31T00:00:00Z", user=test_user)
+        Task.objects.create(
+            name="Task A", reward=10, due_date="2029-12-31T00:00:00Z", user=test_user
+        )
+        Task.objects.create(
+            name="Task B", reward=20, due_date="2029-12-31T00:00:00Z", user=test_user
+        )
+        Task.objects.create(
+            name="Task C", reward=30, due_date="2029-12-31T00:00:00Z", user=test_user
+        )
 
         response = api_client.get("/api/get_task/")
 
@@ -466,8 +474,12 @@ class TestTaskRetrieval:
     ) -> None:
         """Sanity check that retrieval count matches exactly what was created — no duplication or leakage."""
         api_client.force_authenticate(user=test_user)
-        Task.objects.create(name="Only Mine", reward=5, due_date="2029-12-31T00:00:00Z", user=test_user)
-        Task.objects.create(name="Not Mine", reward=5, due_date="2029-12-31T00:00:00Z", user=other_user)
+        Task.objects.create(
+            name="Only Mine", reward=5, due_date="2029-12-31T00:00:00Z", user=test_user
+        )
+        Task.objects.create(
+            name="Not Mine", reward=5, due_date="2029-12-31T00:00:00Z", user=other_user
+        )
 
         response = api_client.get("/api/get_task/")
 

--- a/backend/quickstart/tests.py
+++ b/backend/quickstart/tests.py
@@ -648,6 +648,135 @@ class TestTaskIsolation:
         assert len(names) == 2
         assert all(name.startswith("Theirs") for name in names)
 
+    def test_same_task_name_allowed_across_different_users(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Task names aren't globally unique — two users can each have a task with the same name."""
+        Task.objects.create(name="Homework", reward=10, due_date="2029-12-31", user=test_user)
+        Task.objects.create(name="Homework", reward=20, due_date="2029-12-31", user=other_user)
+
+        assert Task.objects.filter(name="Homework").count() == 2
+        mine = Task.objects.get(name="Homework", user=test_user)
+        theirs = Task.objects.get(name="Homework", user=other_user)
+        assert mine.id != theirs.id
+        assert mine.reward != theirs.reward
+
+    def test_user_cannot_access_task_by_guessing_id(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Sequential/guessable IDs shouldn't let one user fetch another's specific task."""
+        task = Task.objects.create(
+            name="Secret Task", reward=10, due_date="2029-12-31", user=other_user
+        )
+
+        api_client.force_authenticate(user=test_user)
+        response = api_client.get(f"/api/get_task/", data={"id": task.id})
+
+        assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
+
+    def test_isolation_holds_after_switching_authenticated_user_mid_session(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Re-authenticating as a different user on the same client shouldn't leak the previous user's tasks."""
+        api_client.force_authenticate(user=test_user)
+        api_client.post(
+            "/api/create_task/",
+            {"name": "First User Task", "reward": 5, "due_date": "2029-12-31"},
+            format="json",
+        )
+
+        api_client.force_authenticate(user=other_user)
+        response = api_client.get("/api/get_task/")
+
+        names = [t["name"] for t in response.data]
+        assert "First User Task" not in names
+
+    def test_create_task_does_not_expose_other_users_task_count(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Creating a task for one user shouldn't be influenced by or leak another user's existing tasks."""
+        Task.objects.create(name="Existing", reward=10, due_date="2029-12-31", user=other_user)
+
+        api_client.force_authenticate(user=test_user)
+        response = api_client.post(
+            "/api/create_task/",
+            {"name": "New Task", "reward": 5, "due_date": "2029-12-31"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Task.objects.filter(user=test_user).count() == 1
+        assert Task.objects.filter(user=other_user).count() == 1
+
+    def test_get_task_count_matches_only_authenticated_users_tasks(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Total tasks in the DB across all users shouldn't affect what one user sees."""
+        Task.objects.create(name="Mine 1", reward=5, due_date="2029-12-31", user=test_user)
+        Task.objects.create(name="Theirs 1", reward=5, due_date="2029-12-31", user=other_user)
+        Task.objects.create(name="Theirs 2", reward=5, due_date="2029-12-31", user=other_user)
+        Task.objects.create(name="Theirs 3", reward=5, due_date="2029-12-31", user=other_user)
+
+        api_client.force_authenticate(user=test_user)
+        response = api_client.get("/api/get_task/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert Task.objects.count() == 4  # confirms all 4 exist in the DB
+        assert len(response.data) == 1  # but only 1 is visible to test_user
+
+    def test_creating_many_tasks_for_one_user_does_not_appear_for_another(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Bulk creation for one user should never leak into another user's view."""
+        api_client.force_authenticate(user=test_user)
+        for i in range(10):
+            api_client.post(
+                "/api/create_task/",
+                {"name": f"Task {i}", "reward": 1, "due_date": "2029-12-31"},
+                format="json",
+            )
+
+        api_client.force_authenticate(user=other_user)
+        response = api_client.get("/api/get_task/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
+
+    def test_task_reward_values_are_isolated_between_users(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Confirm reward/money fields on tasks aren't cross-contaminated between users' tasks."""
+        Task.objects.create(name="Cheap", reward=1, due_date="2029-12-31", user=test_user)
+        Task.objects.create(name="Expensive", reward=1000, due_date="2029-12-31", user=other_user)
+
+        api_client.force_authenticate(user=test_user)
+        response = api_client.get("/api/get_task/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["reward"] == 1
+
+    def test_get_task_only_returns_own_tasks(
+        self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+    ) -> None:
+        """Create tasks interleaved between two users, confirm isolation without relying on IDs."""
+        api_client.force_authenticate(user=test_user)
+        api_client.post(
+            "/api/create_task/", {"name": "A", "reward": 1, "due_date": "2029-12-31"}, format="json"
+        )
+
+        api_client.force_authenticate(user=other_user)
+        api_client.post(
+            "/api/create_task/", {"name": "B", "reward": 1, "due_date": "2029-12-31"}, format="json"
+        )
+
+        api_client.force_authenticate(user=test_user)
+        response = api_client.get("/api/get_task/")
+        names = [t["name"] for t in response.data]
+
+        assert "A" in names
+        assert "B" not in names
+
 
 # Test Graveyard for tests that get generated but aren't useful *yet*
 
@@ -663,3 +792,61 @@ class TestTaskIsolation:
 #     test_user.delete()
 
 #     assert not Task.objects.filter(name="Cascade Task").exists()
+
+# Isolation Tests! (might need to make a second class)
+
+# def test_user_cannot_delete_another_users_task(
+#         self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+#     ) -> None:
+#         """A user should not be able to delete a task they don't own."""
+#         task = Task.objects.create(
+#             name="Other's Task", reward=10, due_date="2029-12-31", user=other_user
+#         )
+
+#         api_client.force_authenticate(user=test_user)
+#         response = api_client.delete(f"/api/delete_task/{task.id}/")
+
+#         assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
+#         assert Task.objects.filter(id=task.id).exists()
+
+# def test_user_cannot_update_another_users_task(
+#     self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+# ) -> None:
+#     """A user should not be able to modify a task they don't own."""
+#     task = Task.objects.create(
+#         name="Original Name", reward=10, due_date="2029-12-31", user=other_user
+#     )
+
+#     api_client.force_authenticate(user=test_user)
+#     response = api_client.patch(
+#         f"/api/update_task/{task.id}/", {"name": "Hacked Name"}, format="json"
+#     )
+
+#     assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
+#     task.refresh_from_db()
+#     assert task.name == "Original Name"
+
+# def test_deleting_one_user_does_not_affect_other_users_tasks(
+#     self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+# ) -> None:
+#     """Cascade delete should only remove the deleted user's own tasks."""
+#     Task.objects.create(name="Mine", reward=10, due_date="2029-12-31", user=test_user)
+#     Task.objects.create(name="Theirs", reward=10, due_date="2029-12-31", user=other_user)
+
+#     test_user.delete()
+
+#     assert not Task.objects.filter(name="Mine").exists()
+#     assert Task.objects.filter(name="Theirs").exists()
+
+# def test_same_task_name_allowed_across_different_users(
+#     self, api_client: APIClient, test_user: StudyUser, other_user: StudyUser
+# ) -> None:
+#     """Task names aren't globally unique — two users can each have a task with the same name."""
+#     Task.objects.create(name="Homework", reward=10, due_date="2029-12-31", user=test_user)
+#     Task.objects.create(name="Homework", reward=20, due_date="2029-12-31", user=other_user)
+
+#     assert Task.objects.filter(name="Homework").count() == 2
+#     mine = Task.objects.get(name="Homework", user=test_user)
+#     theirs = Task.objects.get(name="Homework", user=other_user)
+#     assert mine.id != theirs.id
+#     assert mine.reward != theirs.reward

--- a/backend/quickstart/tests.py
+++ b/backend/quickstart/tests.py
@@ -37,12 +37,12 @@ def test_task(db: Any, test_user: StudyUser) -> Task:
         name="Test",
         reward=50,
         description="Make sure this works",
-        due_date="2026-12-31",
+        due_date="2026-12-31T00:00:00Z",
         user=test_user,
     )
 
 
-# @pytest.mark.required
+@pytest.mark.required
 @pytest.mark.tasks
 class TestTaskCreation:
     def test_create_task_authenticated(self, api_client: APIClient, test_user: StudyUser) -> None:
@@ -55,7 +55,7 @@ class TestTaskCreation:
             "name": "Math Homework",
             "reward": 50,
             "description": "Finish algebra 1",
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
         response = api_client.post(url, data, format="json")
 
@@ -70,7 +70,7 @@ class TestTaskCreation:
         url = "/api/create_task/"
         data = {
             "name": "Ghost Task",
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post(url, data, format="json")
@@ -86,7 +86,7 @@ class TestTaskCreation:
         """Ensure each submitted task is not empty."""
         api_client.force_authenticate(user=test_user)
 
-        response = api_client.post("/api/create_task", {}, format="json")
+        response = api_client.post("/api/create_task/", {}, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -95,7 +95,7 @@ class TestTaskCreation:
         api_client.force_authenticate(user=test_user)
         data = {
             "reward": 10,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
             "description": "test",
         }
 
@@ -141,7 +141,7 @@ class TestTaskCreation:
         data = {
             "name": "Negative Task",
             "reward": -100,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -153,7 +153,7 @@ class TestTaskCreation:
         data = {
             "name": "Positive Task",
             "reward": 100,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -167,7 +167,7 @@ class TestTaskCreation:
         data = {
             "name": "Late Task",
             "reward": 10,
-            "due_date": "2000-01-01",
+            "due_date": "2000-01-01T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -176,7 +176,7 @@ class TestTaskCreation:
 
     def test_create_task_response_shape(self, api_client: APIClient, test_user: StudyUser):
         api_client.force_authenticate(user=test_user)
-        data = {"name": "Shape Test", "reward": 20, "due_date": "2029-12-31"}
+        data = {"name": "Shape Test", "reward": 20, "due_date": "2029-12-31T00:00:00Z"}
 
         response = api_client.post("/api/create_task/", data, format="json")
 
@@ -195,7 +195,7 @@ class TestTaskCreation:
         data = {
             "name": "No Description Task",
             "reward": 10,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -211,12 +211,26 @@ class TestTaskCreation:
         data = {
             "name": "Zero Reward Task",
             "reward": 0,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
+
+    def test_create_task_excessive_reward(self, api_client: APIClient, test_user: StudyUser) -> None:
+        """A reward higher than the set limit should fail our current basic moderation"""
+        # The value in this test is not 101 because this limit is subject to change
+        api_client.force_authenticate(user=test_user)
+        data = {
+            "name": "Money Farming Task",
+            "reward": 10000000000,
+            "due_date": "2029-12-31T00:00:00Z",
+        }
+
+        response = api_client.post("/api/create_task/", data, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_create_task_reward_as_string(
         self, api_client: APIClient, test_user: StudyUser
@@ -226,7 +240,7 @@ class TestTaskCreation:
         data = {
             "name": "String Reward Task",
             "reward": "50",
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -241,7 +255,7 @@ class TestTaskCreation:
         data = {
             "name": "Bad Reward Task",
             "reward": "not-a-number",
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -259,7 +273,7 @@ class TestTaskCreation:
         api_client.force_authenticate(user=test_user)
         data = {
             "reward": 10,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -273,7 +287,7 @@ class TestTaskCreation:
         data = {
             "name": "Categorized Task",
             "reward": 10,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
             "category": "school",
         }
 
@@ -292,7 +306,7 @@ class TestTaskCreation:
         data = {
             "name": "Uncategorized Task",
             "reward": 10,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
         }
 
         response = api_client.post("/api/create_task/", data, format="json")
@@ -307,7 +321,7 @@ class TestTaskCreation:
         data = {
             "name": "Spoofed User Task",
             "reward": 10,
-            "due_date": "2029-12-31",
+            "due_date": "2029-12-31T00:00:00Z",
             "user": other_user.id,
         }
 
@@ -356,7 +370,7 @@ class TestTaskRetrieval:
             name="Other User Task",
             reward=5,
             description="not visible",
-            due_date="2029-12-31",
+            due_date="2029-12-31T00:00:00Z",
             user=other_user,
         )
 
@@ -407,9 +421,9 @@ class TestTaskRetrieval:
         """A user with several tasks should get all of them back."""
         api_client.force_authenticate(user=test_user)
 
-        Task.objects.create(name="Task A", reward=10, due_date="2029-12-31", user=test_user)
-        Task.objects.create(name="Task B", reward=20, due_date="2029-12-31", user=test_user)
-        Task.objects.create(name="Task C", reward=30, due_date="2029-12-31", user=test_user)
+        Task.objects.create(name="Task A", reward=10, due_date="2029-12-31T00:00:00Z", user=test_user)
+        Task.objects.create(name="Task B", reward=20, due_date="2029-12-31T00:00:00Z", user=test_user)
+        Task.objects.create(name="Task C", reward=30, due_date="2029-12-31T00:00:00Z", user=test_user)
 
         response = api_client.get("/api/get_task/")
 
@@ -452,8 +466,8 @@ class TestTaskRetrieval:
     ) -> None:
         """Sanity check that retrieval count matches exactly what was created — no duplication or leakage."""
         api_client.force_authenticate(user=test_user)
-        Task.objects.create(name="Only Mine", reward=5, due_date="2029-12-31", user=test_user)
-        Task.objects.create(name="Not Mine", reward=5, due_date="2029-12-31", user=other_user)
+        Task.objects.create(name="Only Mine", reward=5, due_date="2029-12-31T00:00:00Z", user=test_user)
+        Task.objects.create(name="Not Mine", reward=5, due_date="2029-12-31T00:00:00Z", user=other_user)
 
         response = api_client.get("/api/get_task/")
 
@@ -479,7 +493,7 @@ class TestTaskRetrieval:
         Task.objects.create(
             name="Categorized",
             reward=10,
-            due_date="2029-12-31",
+            due_date="2029-12-31T00:00:00Z",
             category="school",
             user=test_user,
         )
@@ -496,7 +510,7 @@ class TestTaskRetrieval:
         Task.objects.create(
             name="Type Check",
             reward=42,
-            due_date="2029-07-04",
+            due_date="2029-07-04T00:00:00Z",
             user=test_user,
         )
 
@@ -506,7 +520,7 @@ class TestTaskRetrieval:
         assert response.status_code == status.HTTP_200_OK
         task_data = response.data[0]
         assert task_data["reward"] == 42
-        assert "2029-07-04" in task_data["due_date"]
+        assert "2029-07-04T00:00:00Z" in task_data["due_date"]
 
     def test_get_task_response_is_a_list(
         self, api_client: APIClient, test_user: StudyUser, test_task: Task
@@ -529,7 +543,7 @@ class TestTaskRetrieval:
         """
         for i in range(25):
             Task.objects.create(
-                name=f"Bulk Task {i}", reward=1, due_date="2029-12-31", user=test_user
+                name=f"Bulk Task {i}", reward=1, due_date="2029-12-31T00:00:00Z", user=test_user
             )
 
         api_client.force_authenticate(user=test_user)
@@ -604,7 +618,7 @@ class TestTaskIsolation:
         for i in range(3):
             api_client.post(
                 "/api/create_task/",
-                {"name": f"Mine {i}", "reward": 5, "due_date": "2029-12-31"},
+                {"name": f"Mine {i}", "reward": 5, "due_date": "2029-12-31T00:00:00Z"},
                 format="json",
             )
 
@@ -612,7 +626,7 @@ class TestTaskIsolation:
         for i in range(2):
             api_client.post(
                 "/api/create_task/",
-                {"name": f"Theirs {i}", "reward": 5, "due_date": "2029-12-31"},
+                {"name": f"Theirs {i}", "reward": 5, "due_date": "2029-12-31T00:00:00Z"},
                 format="json",
             )
 
@@ -631,7 +645,7 @@ class TestTaskIsolation:
 #     Task.objects.create(
 #         name="Cascade Task",
 #         reward=10,
-#         due_date="2029-12-31",
+#         due_date="2029-12-31T00:00:00Z",
 #         user=test_user,
 #     )
 #     test_user.delete()


### PR DESCRIPTION
Created an endpoint that will allow users to create a task using data passed from the frontend. Also ensured that the extant tests for task creation pass.

This feature is in a decent state at this point in development, but is probably vulnerable due to a lack of isolation (see #103 for more details). Time zones will be handled by the front end (probably, we'll have something that checks the system time and converts it to UTC because Chrome Extensions have a way to do that apparently?) As always, any other bugs post-approval should be reported as an issue.

Closes #97.